### PR TITLE
show warning and trim matrix when input exceeds seq.

### DIFF
--- a/basmat.c
+++ b/basmat.c
@@ -94,12 +94,13 @@ int intVersion(char *version) {
      bm = Bashicu matrix as input string
      S  = Just allocate memory
      nr = numbers of rows
+     ncmax = available number of columns
    Return variables:
      S  = Bashicu matrix as array of integer
      nc = numbers of columns
      num = Integer as a parameter of BM */
 
-void getMatrix(char *bm, int *S, int nr, long *nc, long *num) {
+void getMatrix(char *bm, int *S, int nr, int ncmax, long *nc, long *num) {
   int len, i, j, m;
   long k;
 
@@ -107,7 +108,15 @@ void getMatrix(char *bm, int *S, int nr, long *nc, long *num) {
   i = j = S[0] = 0;
   for (m = 0; m < len; m++) {
     if (bm[m] == ',') i++, S[i + j * nr] = 0;
-    if (bm[m] == ')') j++, i = 0, S[i + j * nr] = 0;
+    if (bm[m] == ')') {
+      if (j == ncmax) {
+        *nc = j;
+        printf("The number of column exceeds seq=%d.\n",ncmax);
+        printf("The matrix is trimmed.\n");
+        return;
+      }
+      j++, i = 0, S[i + j * nr] = 0;
+    }
     if (bm[m] == '[') {
       for (; m < len; m++) {
         k = bm[m] - '0';
@@ -2152,7 +2161,7 @@ int main(int argc, char *argv[]) {
   }
 
   /* Read Bashicu Matrix */
-  getMatrix(bm, S, nr, &nc, &num);
+  getMatrix(bm, S, nr, s, &nc, &num);
   n = nc - 1;
 
   if (num < 1) num = 2;


### PR DESCRIPTION
Fixes #7 .
Show warning when it exceeds seq.

```
$ ./basmat "(0,0,0)(1,1,1)(2,2,2)(3,3,3)(4,4,4)(5,5,5)(6,6,6)(7,7,7)(8,8,8)(9,9,9)(10,10,10)(11,11,11)(12,12,12)(13,13,13)(14,14,14)(15,15,15)(16,16,16)(17,17,17)(18,18,18)(19,19,19)(20,20,20)(21,21,21)(22,22,22)(23,23,23)(24,24,24)(25,25,25)(26,26,26)"
The number of column exceeds seq=20.
The matrix is trimmed.
(0,0,0)(1,1,1)(2,2,2)(3,3,3)(4,4,4)(5,5,5)(6,6,6)(7,7,7)(8,8,8)(9,9,9)(10,10,10)(11,11,11)(12,12,12)(13,13,13)(14,14,14)(15,15,15)(16,16,16)(17,17,17)(18,18,18)(19,19,19)[2]
```